### PR TITLE
initVid function initial fix proposal

### DIFF
--- a/math-interactive-img.js
+++ b/math-interactive-img.js
@@ -127,11 +127,14 @@ img.onload = function() {
 source.init({ src: img, dynamic: false });};
 }
 window.initVid = function(source,url){
-var img = document.createElement('img');
-img.crossOrigin = "anonymous";
-img.src = url;
-img.onload = function() {
-source.init({ src: img, dynamic: true });};
+var vid = document.createElement('video');
+vid.crossOrigin = "anonymous";
+vid.autoplay = true;
+vid.loop = true;
+vid.muted = true;
+// vid.onload = function() { };
+vid.src = url;
+source.init({ src: vid });
 }
 //img funcs
 osc().constructor.prototype.correctScale = function(source){


### PR DESCRIPTION
@ritchse

# Why?

Because in order to load a video, a 'video' tag should be created _instead_ of a 'img' tag.

# Steps to reproduce

1. run antlia `math-interactive-img.js` in `atom-hydra`
2. run `initVid` with appropriate arguments
3. Nothing happens

![antlia-video-issue](https://user-images.githubusercontent.com/165956/135783151-3418fe90-8aaf-4e09-95f6-3b80998cf5d0.gif)

# Partial fix

- The fix is partial because I haven't been able to run it in the hydra web app
- The fix is partial because I'm not using the `onload`  callback function
- The fix is partial because even though that the video actually loads, there is an error log in the hydra log console that says `(regl) invalid texture shape` 

![antlia-video-fix](https://user-images.githubusercontent.com/165956/135783315-ac0077eb-6ae3-45c5-912a-ad6fdab2766b.gif)


